### PR TITLE
Unifiy CXX standard across the project makefiles

### DIFF
--- a/src/lib/spoa/CMakeLists.txt
+++ b/src/lib/spoa/CMakeLists.txt
@@ -5,7 +5,7 @@ project(spoa VERSION 4.0.8
              DESCRIPTION "Spoa is a c++ library (and tool) for SIMD vectorized partial order alignment.")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/src/lib/spoa/spoa/CMakeLists.txt
+++ b/src/lib/spoa/spoa/CMakeLists.txt
@@ -5,7 +5,7 @@ project(spoa VERSION 4.0.8
              DESCRIPTION "Spoa is a c++ library (and tool) for SIMD vectorized partial order alignment.")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/src/projects/dbg/CMakeLists.txt
+++ b/src/projects/dbg/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(debruijn)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 
 add_library(lja_dbg STATIC sparse_dbg.cpp graph_algorithms.cpp dbg_disjointigs.cpp dbg_construction.cpp

--- a/src/projects/error_correction/CMakeLists.txt
+++ b/src/projects/error_correction/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(debruijn)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 add_library(lja_ec STATIC correction_utils.cpp manyk_correction.cpp multiplicity_estimation.cpp tournament_correction.cpp
         dimer_correction.cpp tip_correction.cpp mult_correction.cpp precorrection.cpp diploidy_analysis.cpp

--- a/src/projects/scripts/CMakeLists.txt
+++ b/src/projects/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(scripts)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 #add_executable(analyse_hifi main.cpp)
 #add_executable(count_perfect count_perfect.cpp)
 #add_executable(analyse_positions position_analysis.cpp)

--- a/src/projects/supregraph/CMakeLists.txt
+++ b/src/projects/supregraph/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(debruijn)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 
 add_library(lja_spg STATIC supregraph.cpp vertex_resolution.cpp supregraph_base.cpp unique_vertex_storage.cpp converter.hpp read_storage.cpp list_path.cpp decision_rules.cpp listeners.cpp)

--- a/src/tools/alignment/CMakeLists.txt
+++ b/src/tools/alignment/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(alignment)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 include_directories(.)
 add_library(lja_alignment STATIC ksw_aligner.cpp alignment_form.cpp)

--- a/src/tools/common/CMakeLists.txt
+++ b/src/tools/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(common)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 include_directories(.)
 add_library(lja_common STATIC cl_parser.cpp oneline_utils.hpp pipeline_tools.cpp object_id.hpp rolling_hash.cpp)

--- a/src/tools/sequences/CMakeLists.txt
+++ b/src/tools/sequences/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(sequences)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 include_directories(.)
 add_library(lja_sequence STATIC contigs.cpp sequence.cpp)


### PR DESCRIPTION
Small refactoring:

- unifies CXX standard to 17 across makefiles in the project
- successfully built following targets: jumboDBG, lja and align_and_print using the updated project configuration